### PR TITLE
[search-through-lists] Search through selection prompts for easier navigation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added search functionality to selection prompts for easier navigation through long lists. Users can type to filter options in real-time with clear "(type to search)" hints.
+  - Reviewer selection
+  - Branch selection
+  - Branch tracking
+  - File selection
+
 ### Changed
 
 - Migrated CLI from Click to Typer

--- a/src/panqake/commands/down.py
+++ b/src/panqake/commands/down.py
@@ -45,10 +45,9 @@ def down():
             child_item = {"display": child, "value": child}
             choices.append(child_item)
 
-        # Show interactive branch selection
+        # Show interactive branch selection with search enabled
         selected = prompt_select(
-            "Select a child branch to switch to:",
-            choices,
+            "Select a child branch to switch to:", choices, enable_search=True
         )
 
         if selected:

--- a/src/panqake/commands/modify.py
+++ b/src/panqake/commands/modify.py
@@ -157,8 +157,13 @@ def modify_commit(commit_flag=False, message=None, no_amend=False):
         print_formatted_text("[info]The following files have unstaged changes:[/info]")
 
         # Prompt user to select files to stage
+        # Enable search if there are many files
+        enable_search = len(unstaged_files) > 10
         selected_items = prompt_checkbox(
-            "Select files to stage (optional):", unstaged_files, default=unstaged_files
+            "Select files to stage (optional):",
+            unstaged_files,
+            default=unstaged_files,
+            enable_search=enable_search,
         )
 
         # selected_items will be a list of the selected files' paths

--- a/src/panqake/commands/pr.py
+++ b/src/panqake/commands/pr.py
@@ -48,7 +48,9 @@ def prompt_for_reviewers(potential_reviewers):
         {"name": reviewer, "value": reviewer} for reviewer in potential_reviewers
     ]
 
-    selected = prompt_checkbox("Select reviewers (optional):", choices, default=[])
+    selected = prompt_checkbox(
+        "Select reviewers (optional):", choices, default=[], enable_search=True
+    )
 
     # Filter out empty selections (skip option)
     return [reviewer for reviewer in selected if reviewer]

--- a/src/panqake/commands/switch.py
+++ b/src/panqake/commands/switch.py
@@ -57,9 +57,9 @@ def switch_branch(branch_name=None):
         return
 
     # Show interactive branch selection using the prompt_select function
+    # Always enable search for branch selection
     selected = prompt_select(
-        "Select a branch to switch to:",
-        choices,
+        "Select a branch to switch to:", choices, enable_search=True
     )
 
     if selected:

--- a/tests/panqake/utils/test_questionary_prompt.py
+++ b/tests/panqake/utils/test_questionary_prompt.py
@@ -123,6 +123,30 @@ def test_prompt_checkbox_with_dict_choices(mock_questionary):
     assert result == ["item1", "item2"]
 
 
+def test_prompt_checkbox_with_search_enabled(mock_questionary):
+    """Test checkbox selection with search enabled."""
+    choices = [f"item{i}" for i in range(15)]  # Create a long list
+    result = prompt_checkbox("Select items:", choices, enable_search=True)
+    mock_questionary["checkbox"].assert_called_once()
+
+    # Verify that use_search_filter was passed as True
+    call_args = mock_questionary["checkbox"].call_args
+    assert call_args[1]["use_search_filter"] is True
+    assert result == ["item1", "item2"]
+
+
+def test_prompt_checkbox_search_disabled(mock_questionary):
+    """Test checkbox selection with search disabled."""
+    choices = ["item1", "item2", "item3"]  # Short list
+    result = prompt_checkbox("Select items:", choices, enable_search=False)
+    mock_questionary["checkbox"].assert_called_once()
+
+    # Verify that use_search_filter was passed as False
+    call_args = mock_questionary["checkbox"].call_args
+    assert call_args[1]["use_search_filter"] is False
+    assert result == ["item1", "item2"]
+
+
 def test_prompt_select(mock_questionary):
     """Test single selection prompt."""
     choices = ["option1", "option2"]
@@ -142,11 +166,39 @@ def test_prompt_select_with_dict_choices(mock_questionary):
     assert result == "selected"
 
 
+def test_prompt_select_with_search_enabled(mock_questionary):
+    """Test select prompt with search enabled."""
+    choices = [f"option{i}" for i in range(15)]  # Create a long list
+    result = prompt_select("Select one:", choices, enable_search=True)
+    mock_questionary["select"].assert_called_once()
+
+    # Verify that use_search_filter was passed as True
+    call_args = mock_questionary["select"].call_args
+    assert call_args[1]["use_search_filter"] is True
+    assert result == "selected"
+
+
+def test_prompt_select_search_disabled(mock_questionary):
+    """Test select prompt with search disabled."""
+    choices = ["option1", "option2", "option3"]  # Short list
+    result = prompt_select("Select one:", choices, enable_search=False)
+    mock_questionary["select"].assert_called_once()
+
+    # Verify that use_search_filter was passed as False
+    call_args = mock_questionary["select"].call_args
+    assert call_args[1]["use_search_filter"] is False
+    assert result == "selected"
+
+
 def test_prompt_for_parent(mock_questionary):
     """Test parent branch selection prompt."""
     branches = ["main", "develop", "feature"]
     result = prompt_for_parent(branches)
     mock_questionary["select"].assert_called_once()
+
+    # Verify that search is always enabled for parent selection
+    call_args = mock_questionary["select"].call_args
+    assert call_args[1]["use_search_filter"] is True
     assert result == "selected"
 
 
@@ -154,6 +206,18 @@ def test_prompt_for_parent_empty_list():
     """Test parent branch selection with empty list."""
     result = prompt_for_parent([])
     assert result is None
+
+
+def test_prompt_for_parent_always_enables_search(mock_questionary):
+    """Test parent branch selection always enables search regardless of list size."""
+    branches = ["main", "develop", "feature"]  # Small list
+    result = prompt_for_parent(branches)
+    mock_questionary["select"].assert_called_once()
+
+    # Verify that use_search_filter is always True for parent selection
+    call_args = mock_questionary["select"].call_args
+    assert call_args[1]["use_search_filter"] is True
+    assert result == "selected"
 
 
 def test_branch_name_validator_valid():


### PR DESCRIPTION
:tea:

- Added search functionality to selection prompts for easier navigation through long lists. Users can type to filter options in real-time with clear "(type to search)" hints.
  - Reviewer selection
  - Branch selection
  - Branch tracking
  - File selection