### PR TITLE
[worktrees] Create and manage git worktrees

### DIFF
--- a/src/panqake/cli.py
+++ b/src/panqake/cli.py
@@ -76,9 +76,10 @@ app = typer.Typer(
 def new(
     branch_name: str | None = typer.Argument(None, help="Name of the new branch"),
     base_branch: str | None = typer.Argument(None, help="Parent branch"),
+    tree: bool = typer.Option(False, "--tree", help="Create branch in a new worktree"),
 ):
     """Create a new branch in the stack."""
-    create_new_branch(branch_name, base_branch)
+    create_new_branch(branch_name, base_branch, tree)
 
 
 @app.command(name="list")

--- a/src/panqake/commands/down.py
+++ b/src/panqake/commands/down.py
@@ -2,10 +2,12 @@
 
 import sys
 
-from panqake.utils.git import checkout_branch, get_current_branch
+from panqake.utils.git import (
+    get_current_branch,
+    switch_to_branch_or_worktree,
+)
 from panqake.utils.questionary_prompt import print_formatted_text, prompt_select
 from panqake.utils.stack import Stacks
-from panqake.utils.status import status
 
 
 def down() -> None:
@@ -37,8 +39,7 @@ def down() -> None:
         if len(children) == 1:
             child = children[0]
             print_formatted_text(f"[info]Moving down to child branch: '{child}'[/info]")
-            with status(f"Switching to child branch '{child}'..."):
-                checkout_branch(child)
+            switch_to_branch_or_worktree(child, "child branch")
             return
 
         # Multiple children, prompt for selection
@@ -61,5 +62,4 @@ def down() -> None:
             print_formatted_text(
                 f"[info]Moving down to child branch: '{selected}'[/info]"
             )
-            with status(f"Switching to child branch '{selected}'..."):
-                checkout_branch(selected)
+            switch_to_branch_or_worktree(selected, "child branch")

--- a/src/panqake/commands/merge.py
+++ b/src/panqake/commands/merge.py
@@ -11,6 +11,7 @@ from panqake.utils.config import (
     add_to_stack,
     get_child_branches,
     get_parent_branch,
+    get_worktree_path,
     remove_from_stack,
 )
 from panqake.utils.git import (
@@ -141,6 +142,19 @@ def update_child_branches(branch_name, parent_branch, current_branch):
 def cleanup_local_branch(branch_name):
     """Delete the local branch after successful merge."""
     if branch_exists(branch_name):
+        # Check if branch has a worktree that needs cleanup
+        worktree_path = get_worktree_path(branch_name)
+
+        # If branch has a worktree, inform user to manually delete it
+        if worktree_path:
+            print_formatted_text(
+                f"\n[warning]Branch '{branch_name}' has a worktree at: {worktree_path}[/warning]"
+            )
+            print_formatted_text("[info]To complete cleanup, please:[/info]")
+            print_formatted_text("[info]1. cd out of the worktree directory[/info]")
+            print_formatted_text(f"[info]2. Run: pq delete {branch_name}[/info]")
+            return False
+
         with status(f"Deleting local branch {branch_name}...") as s:
             # Make sure we're not on the branch we're trying to delete
             current = get_current_branch()

--- a/src/panqake/commands/new.py
+++ b/src/panqake/commands/new.py
@@ -1,9 +1,11 @@
 """Command for creating a new branch in the stack."""
 
 import sys
+from pathlib import Path
 
 from panqake.utils.config import add_to_stack
 from panqake.utils.git import (
+    add_worktree,
     branch_exists,
     create_branch,
     get_current_branch,
@@ -21,7 +23,9 @@ from panqake.utils.types import BranchName
 
 
 def create_new_branch(
-    branch_name: BranchName | None = None, base_branch: BranchName | None = None
+    branch_name: BranchName | None = None,
+    base_branch: BranchName | None = None,
+    use_worktree: bool = False,
 ) -> None:
     """Create a new branch in the stack."""
     # If no branch name specified, prompt for it
@@ -41,6 +45,16 @@ def create_new_branch(
                 default=current or "",
             )
 
+    # Determine worktree path if using worktree
+    worktree_path = ""
+    if use_worktree:
+        worktree_path = str(Path.cwd() / branch_name)
+        if Path(worktree_path).exists():
+            print_formatted_text(
+                f"[warning]Error: Directory '{worktree_path}' already exists[/warning]"
+            )
+            sys.exit(1)
+
     with status("Creating new branch...") as s:
         # Check if the new branch already exists
         s.update("Checking if branch name is available...")
@@ -58,15 +72,38 @@ def create_new_branch(
             s.pause_and_print("[danger]Error: Base branch is required[/danger]")
             sys.exit(1)
 
-        # Create the new branch
-        s.update(f"Creating branch '{branch_name}' from '{base_branch}'...")
-        create_branch(branch_name, base_branch)
+        if use_worktree:
+            # Create the new branch in a worktree
+            s.update(f"Creating worktree at '{worktree_path}'...")
+            if not add_worktree(branch_name, worktree_path, base_branch):
+                s.pause_and_print("[danger]Error: Failed to create worktree[/danger]")
+                sys.exit(1)
 
-        # Record the dependency information
-        s.update("Adding branch to stack metadata...")
-        add_to_stack(branch_name, base_branch)
+            # Record the dependency information with worktree path
+            s.update("Adding branch to stack metadata...")
+            add_to_stack(branch_name, base_branch, worktree_path)
+        else:
+            # Create the new branch normally
+            s.update(f"Creating branch '{branch_name}' from '{base_branch}'...")
+            create_branch(branch_name, base_branch)
 
-    print_formatted_text(
-        f"[success]Success! Created new branch '{branch_name}' in the stack[/success]"
-    )
-    print_formatted_text(f"[info]Parent branch: {format_branch(base_branch)}[/info]")
+            # Record the dependency information
+            s.update("Adding branch to stack metadata...")
+            add_to_stack(branch_name, base_branch)
+
+    if use_worktree:
+        print_formatted_text(
+            f"[success]Success! Created new branch '{branch_name}' in worktree at '{worktree_path}'[/success]"
+        )
+        print_formatted_text(
+            f"[info]Parent branch: {format_branch(base_branch)}[/info]"
+        )
+        print_formatted_text("\n[info]To switch to the new worktree, run:[/info]")
+        print_formatted_text(f"[info]cd {worktree_path}[/info]")
+    else:
+        print_formatted_text(
+            f"[success]Success! Created new branch '{branch_name}' in the stack[/success]"
+        )
+        print_formatted_text(
+            f"[info]Parent branch: {format_branch(base_branch)}[/info]"
+        )

--- a/src/panqake/commands/switch.py
+++ b/src/panqake/commands/switch.py
@@ -3,10 +3,13 @@
 import sys
 
 from panqake.commands.list import list_branches
-from panqake.utils.git import checkout_branch, get_current_branch, list_all_branches
+from panqake.utils.git import (
+    get_current_branch,
+    list_all_branches,
+    switch_to_branch_or_worktree,
+)
 from panqake.utils.questionary_prompt import print_formatted_text
 from panqake.utils.selection import select_branch_excluding_current
-from panqake.utils.status import status
 
 
 def switch_branch(branch_name=None):
@@ -37,8 +40,7 @@ def switch_branch(branch_name=None):
             print_formatted_text(f"[info]Already on branch '{branch_name}'[/info]")
             return
 
-        with status(f"Switching to branch '{branch_name}'..."):
-            checkout_branch(branch_name)
+        switch_to_branch_or_worktree(branch_name)
         return
 
     # First show the branch hierarchy
@@ -58,8 +60,7 @@ def switch_branch(branch_name=None):
         return
 
     if selected:
-        with status(f"Switching to branch '{selected}'..."):
-            checkout_branch(selected)
+        switch_to_branch_or_worktree(selected)
         print_formatted_text("")
         # Show the branch hierarchy again
         list_branches()

--- a/src/panqake/commands/up.py
+++ b/src/panqake/commands/up.py
@@ -2,10 +2,12 @@
 
 import sys
 
-from panqake.utils.git import checkout_branch, get_current_branch
+from panqake.utils.git import (
+    get_current_branch,
+    switch_to_branch_or_worktree,
+)
 from panqake.utils.questionary_prompt import print_formatted_text
 from panqake.utils.stack import Stacks
-from panqake.utils.status import status
 
 
 def up() -> None:
@@ -32,5 +34,4 @@ def up() -> None:
             sys.exit(1)
 
         print_formatted_text(f"[info]Moving up to parent branch: '{parent}'[/info]")
-        with status(f"Switching to parent branch '{parent}'..."):
-            checkout_branch(parent)
+        switch_to_branch_or_worktree(parent, "parent branch")

--- a/src/panqake/utils/config.py
+++ b/src/panqake/utils/config.py
@@ -30,10 +30,12 @@ def get_child_branches(branch: BranchName) -> list[BranchName]:
     return stacks.get_children(branch)
 
 
-def add_to_stack(branch: BranchName, parent: ParentBranchName) -> None:
+def add_to_stack(
+    branch: BranchName, parent: ParentBranchName, worktree: str = ""
+) -> None:
     """Add a branch to the stack."""
     stacks = Stacks()
-    stacks.add_branch(branch, parent)
+    stacks.add_branch(branch, parent, worktree)
 
 
 def remove_from_stack(branch: BranchName) -> bool:
@@ -50,3 +52,15 @@ def remove_from_stack(branch: BranchName) -> bool:
     """
     stacks = Stacks()
     return stacks.remove_branch(branch)
+
+
+def get_worktree_path(branch: BranchName) -> str:
+    """Get the worktree path for the given branch."""
+    stacks = Stacks()
+    return stacks.get_worktree(branch)
+
+
+def set_worktree_path(branch: BranchName, path: str) -> bool:
+    """Set the worktree path for a branch."""
+    stacks = Stacks()
+    return stacks.set_worktree(branch, path)

--- a/src/panqake/utils/types.py
+++ b/src/panqake/utils/types.py
@@ -11,8 +11,9 @@ RepoId: TypeAlias = str
 BranchName: TypeAlias = str
 # Empty string indicates root branch (no parent)
 ParentBranchName: TypeAlias = str
-# Contains "parent" key mapping to parent branch name
-BranchMetadata: TypeAlias = dict[str, ParentBranchName]
+WorktreePath: TypeAlias = str
+# Contains "parent" key mapping to parent branch name, and optional "worktree" key
+BranchMetadata: TypeAlias = dict[str, ParentBranchName | WorktreePath]
 BranchObject: TypeAlias = "Branch"
 RepoBranches: TypeAlias = dict[BranchName, BranchObject]
 StacksData: TypeAlias = dict[RepoId, RepoBranches]

--- a/tests/panqake/commands/test_down.py
+++ b/tests/panqake/commands/test_down.py
@@ -11,7 +11,7 @@ from panqake.commands.down import down
 def mock_git_utils():
     """Mock git utility functions."""
     with (
-        patch("panqake.commands.down.checkout_branch") as mock_checkout,
+        patch("panqake.commands.down.switch_to_branch_or_worktree") as mock_checkout,
         patch("panqake.commands.down.get_current_branch") as mock_current,
     ):
         mock_current.return_value = "main"
@@ -55,7 +55,7 @@ def test_down_with_single_child(mock_git_utils, mock_stacks, mock_prompt):
     mock_stacks.get_children.assert_called_once_with("main")
 
     # Check that we checked out the child branch
-    mock_git_utils["checkout"].assert_called_once_with("feature")
+    mock_git_utils["checkout"].assert_called_once_with("feature", "child branch")
 
     # Check that we printed a message
     mock_prompt["print"].assert_called_once()
@@ -91,7 +91,7 @@ def test_down_with_multiple_children(mock_git_utils, mock_stacks, mock_prompt):
     assert [c["value"] for c in choices] == ["feature-a", "feature-b", "feature-c"]
 
     # Check that we checked out the selected branch
-    mock_git_utils["checkout"].assert_called_once_with("feature-b")
+    mock_git_utils["checkout"].assert_called_once_with("feature-b", "child branch")
 
 
 def test_down_with_multiple_children_cancel(mock_git_utils, mock_stacks, mock_prompt):

--- a/tests/panqake/commands/test_switch.py
+++ b/tests/panqake/commands/test_switch.py
@@ -13,7 +13,7 @@ def mock_git_utils():
     with (
         patch("panqake.commands.switch.list_all_branches") as mock_list,
         patch("panqake.commands.switch.get_current_branch") as mock_current,
-        patch("panqake.commands.switch.checkout_branch") as mock_checkout,
+        patch("panqake.commands.switch.switch_to_branch_or_worktree") as mock_checkout,
     ):
         mock_list.return_value = ["main", "feature", "develop"]
         mock_current.return_value = "main"

--- a/tests/panqake/commands/test_up.py
+++ b/tests/panqake/commands/test_up.py
@@ -11,7 +11,7 @@ from panqake.commands.up import up
 def mock_git_utils():
     """Mock git utility functions."""
     with (
-        patch("panqake.commands.up.checkout_branch") as mock_checkout,
+        patch("panqake.commands.up.switch_to_branch_or_worktree") as mock_checkout,
         patch("panqake.commands.up.get_current_branch") as mock_current,
     ):
         mock_current.return_value = "feature"
@@ -49,7 +49,7 @@ def test_up_with_parent(mock_git_utils, mock_stacks, mock_print):
     mock_stacks.get_parent.assert_called_once_with("feature")
 
     # Check that we checked out the parent branch
-    mock_git_utils["checkout"].assert_called_once_with("main")
+    mock_git_utils["checkout"].assert_called_once_with("main", "parent branch")
 
     # Check that we printed a message
     mock_print.assert_called_once()


### PR DESCRIPTION
Experimental support for git worktrees.

- Create new worktree using `pq new --tree`: this will create a worktree instead of a branch in the main worktree
- Create prs and manage worktrees using all existing commands
