### PR TITLE
Fixed error when staging deleted files in `pq modify` command

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed error when staging deleted files in `pq modify` command - now uses `git rm --cached` for deleted files instead of `git add -A`
+
 ## v0.20.0 - 2025-07-02
 
 ### Changed

--- a/tests/panqake/commands/test_modify.py
+++ b/tests/panqake/commands/test_modify.py
@@ -163,9 +163,9 @@ def test_stage_selected_files_deleted(mock_git_utils, mock_prompt):
     # Verify
     assert result is True
     assert mock_git_utils["run"].call_count == 2
-    # Verify that git add -A was used for deleted files
-    mock_git_utils["run"].assert_any_call(["add", "-A", "--", "deleted.py"])
-    mock_git_utils["run"].assert_any_call(["add", "-A", "--", "also_deleted.py"])
+    # Verify that git rm --cached was used for deleted files
+    mock_git_utils["run"].assert_any_call(["rm", "--cached", "--", "deleted.py"])
+    mock_git_utils["run"].assert_any_call(["rm", "--cached", "--", "also_deleted.py"])
 
 
 def test_stage_selected_files_mixed(mock_git_utils, mock_prompt):
@@ -192,8 +192,9 @@ def test_stage_selected_files_mixed(mock_git_utils, mock_prompt):
     assert mock_git_utils["run"].call_count == 5
     # Verify git add -A was used for regular files
     mock_git_utils["run"].assert_any_call(["add", "-A", "--", "modified.py"])
-    mock_git_utils["run"].assert_any_call(["add", "-A", "--", "deleted.py"])
     mock_git_utils["run"].assert_any_call(["add", "-A", "--", "new.py"])
+    # Verify git rm --cached was used for deleted files
+    mock_git_utils["run"].assert_any_call(["rm", "--cached", "--", "deleted.py"])
     # Verify rename handling
     mock_git_utils["run"].assert_any_call(["add", "--", "old.py"])
     mock_git_utils["run"].assert_any_call(["add", "--", "renamed.py"])


### PR DESCRIPTION
Fixed error when staging deleted files in `pq modify` command - now uses `git rm --cached` for deleted files instead of `git add -A`